### PR TITLE
Adding a new `battery_total_kwh_capacity`.

### DIFF
--- a/vehicle-api/src/vehicles.ts
+++ b/vehicle-api/src/vehicles.ts
@@ -575,6 +575,13 @@ export class VehicleSignalManager {
         default: DEFAULT_PERCENTAGE,
     })
     public battery_state_of_charge() { /* battery state of charge */ }
+    
+    @VehicleSignal({
+        validator: validateNumber(false, {14.5, 23.5),
+        transformer: transformToNumber(),
+        default: 17.5,
+    })
+    public battery_total_kwh_capacity() { /* capacity of the car's battery in kWh */ }
 
     @VehicleSignal({
         validator: validatePercentage(),


### PR DESCRIPTION
Having only `battery_state_of_charge` doesn't tell us how many kWh the car still has if we don't know its battery capacity, which depends on it being a e.GO Life 20 (14,5 kWh), 40 (17,5 kWh) or 60 (23,5 kWh).