### PR TITLE
Web app should say `kWh` for capacity over time.

### DIFF
--- a/vehicle-api/webapp/src/views/Home.vue
+++ b/vehicle-api/webapp/src/views/Home.vue
@@ -116,7 +116,7 @@
                   <td>
                     <p
                       @click="showSliderDialog(14, 24, 'battery_total_kwh_capacity', signals.battery_total_kwh_capacity, false)"
-                    >{{ signals.battery_total_kwh_capacity }} kW</p>
+                    >{{ signals.battery_total_kwh_capacity }} kWh</p>
                   </td>
                 </tr>
                 <tr :class="matchSearch('brake_fluid_level') ? 'hightlighted' : ''">


### PR DESCRIPTION
`kW` is power at a given moment.

Also GitHub added for us a newline at the end, which is a good convention anyways.